### PR TITLE
fix: provide correct minimal required rent for program address

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ fn deploy(args: DeployArgs) {
     let buffer_len = rpc_client.get_account_data(&args.buffer).unwrap().len();
     // I forgot the header len so let's just add 64 for now lol
     let rent = rpc_client
-        .get_minimum_balance_for_rent_exemption(64 + buffer_len)
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_program())
         .expect("failed to fetch rent");
 
     // Create account with seed


### PR DESCRIPTION
Currently, we are passing programdata's rent into program_rent. We only need rent for program's state when creating program account.