### PR TITLE
Feat: Fix linking error when building with the `deploy` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "A *bLaZinGlY fAsT* tool for grinding vanity addresses on Solana"
 
 [features]
 gpu = ["cc"]
-deploy = ["solana-rpc-client"]
+deploy = ["solana-rpc-client","solana-sdk"]
 default = []
 
 [profile.release]


### PR DESCRIPTION
The `deploy` feature didn't properly add the solana-sdk as a dependency. 