### PR TITLE
Support multiple vanity search targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ No ed25519 is involved, so it's dramatically faster — but the account is
 controlled by `base` (the signer), not by a standalone keypair.
 
 You supply the `--base` pubkey (the signer for the create instruction), the
-program `--owner`, and a `--prefix` and/or `--suffix` to match (base58):
+program `--owner`, and one or more `--prefix` and/or `--suffix` values to
+match (base58):
 
 ```bash
 vanity grind \
@@ -111,7 +112,10 @@ path uses a batched custom ed25519 implementation (AVX-512 IFMA when available);
 GPUs use the CUDA/OpenCL keypair kernels.
 
 ```bash
-vanity grind-keypair --prefix bob --suffix xyz --num-gpus 1
+vanity grind-keypair \
+  --prefix sun,moon,mint \
+  --suffix key \
+  --num-gpus 1
 ```
 
 On a match it prints the public key, the seed (hex), and a Solana-compatible
@@ -126,6 +130,23 @@ keypair json (solana-compatible): [104, 227, 111, ...]
 
 Add `--case-insensitive` to match the prefix/suffix ignoring case (except `L`,
 which has no lowercase form in base58).
+
+Multiple values use OR within each flag and AND between the two flags. For
+example, the command above matches a public key that starts with `sun`, `moon`,
+or `mint` and ends with `key`. Values can be comma-separated or supplied by
+repeating a flag; these commands are equivalent:
+
+```bash
+vanity grind-keypair --prefix sun,moon,mint --suffix key
+vanity grind-keypair --prefix sun --prefix moon --prefix mint --suffix key
+```
+
+The same syntax is supported by `grind`. Existing single-value commands remain
+unchanged.
+
+CUDA and OpenCL searches accept up to 32 non-redundant values per flag. CPU-only
+searches do not have this limit. Duplicate targets and targets covered by a
+shorter alternative are removed automatically before the search starts.
 
 ### Grind a doppler keypair
 
@@ -177,7 +198,7 @@ doppler: 1/4 sign-extendable segment(s)
 | `--num-gpus <N>` | all (GPU builds only) | `1` | GPUs to mine on |
 | `--count <N>` | all | `1` | stop after finding N matches |
 | `--case-insensitive` | `grind`, `grind-keypair` | off | match prefix/suffix ignoring case |
-| `--prefix` / `--suffix` | `grind`, `grind-keypair` | — | base58 target(s) to match; supply at least one |
+| `--prefix` / `--suffix` | `grind`, `grind-keypair` | — | base58 targets to match; repeat or separate with commas; supply at least one |
 | `--segments <1-4>` | `grind-doppler` | `1` | sign-extendable segments required |
 
 To run purely on CPU (no GPU), build without a GPU feature, or pass `--num-gpus 0`.

--- a/build.rs
+++ b/build.rs
@@ -23,6 +23,13 @@ fn build_cuda_libs() {
         .file("kernels/sha256.cu")
         .flag("-cudart=static");
 
+    // Cargo's release profile keeps Rust debug symbols, but forwarding that
+    // setting to nvcc enables `-G` device-debug code and can reduce kernel
+    // throughput by orders of magnitude. Keep `-G` available in debug builds.
+    if std::env::var("PROFILE").as_deref() == Ok("release") {
+        build.debug(false);
+    }
+
     // Which GPU architectures to generate code for. A cubin built for one
     // compute capability only runs on that capability (e.g. an sm_89 cubin
     // will NOT load on an sm_86 RTX 3090), and PTX only JITs *upward*, so a

--- a/kernels/base58.h
+++ b/kernels/base58.h
@@ -10,28 +10,32 @@ extern __device__ uint8_t const base58_chars_ci[];
 extern __device__ uint const enc_table_32[8][8];
 extern __constant__ uint8_t d_match_lut[58];
 
+#define VANITY_MATCH_PLAN_WORDS (1U + 44U * 58U + 44U)
+
 __device__ ulong fd_base58_encode_32(uint8_t *bytes, uint8_t *out, bool case_insensitive);
 
-/* Word-form fused base58 encode + prefix/suffix match with early
+/* Word-form fused base58 encode + prefix/suffix OR match with early
    rejection. Caller passes the SHA-256 digest as 8 native uint words
    (state[0..7], MSB-first interpretation), avoiding the byte-emit /
    byte-load / byte-swap roundtrip that the byte-form caller forced
    us into previously. The two byte-swaps cancel exactly:
    binary[i] == state[i].
 
-   `target` and `suffix` are arrays of canonical raw_base58 indices
-   (0..57) precomputed on the host via gpu_grind_init. d_match_lut folds
-   raw_base58 values into the same canonical space, so neither a
-   b58_chars[] lookup nor a case_insensitive branch is in the path.
+   Prefix and suffix plans contain candidate bitmasks for each character and
+   position, precomputed on the host. d_match_lut folds raw_base58 values into
+   the same canonical space, so neither a b58_chars[] lookup nor a
+   case_insensitive branch is in the path.
 
    Inlined into the call site so __launch_bounds__ register caps on the
    parent kernel apply transitively. */
 static __device__ __forceinline__ bool fd_base58_check_match_32_words(const uint state[8],
-                                                                       const uint8_t *target,
-                                                                       ulong target_len,
-                                                                       const uint8_t *suffix,
-                                                                       ulong suffix_len)
+                                                                      const uint8_t *prefixes,
+                                                                      ulong prefix_count,
+                                                                      const uint8_t *suffixes,
+                                                                      ulong suffix_count)
 {
+    (void)prefix_count;
+    (void)suffix_count;
     /* Count leading zero bytes of the big-endian byte view of state[].
        Each word contributes 0..4 leading zero bytes; advance through
        words that are entirely zero. __clz lowers to a single SFU op. */
@@ -58,7 +62,6 @@ static __device__ __forceinline__ bool fd_base58_check_match_32_words(const uint
     }
 
     uint8_t raw_base58[45];
-    ulong limbs_done = 0UL;
     #define VANITY_BS58_EMIT_LIMB(L) do { \
         uint v = (uint)intermediate[(L)]; \
         raw_base58[5UL*(L) + 4UL] = (uint8_t)((v / 1U) % 58U); \
@@ -67,17 +70,13 @@ static __device__ __forceinline__ bool fd_base58_check_match_32_words(const uint
         raw_base58[5UL*(L) + 1UL] = (uint8_t)((v / 195112U) % 58U); \
         raw_base58[5UL*(L) + 0UL] = (uint8_t)(v / 11316496U); \
     } while (0)
-    #define VANITY_BS58_ENSURE_LIMB(L) do { \
-        while (limbs_done <= (L)) { VANITY_BS58_EMIT_LIMB(limbs_done); limbs_done++; } \
-    } while (0)
-
-    VANITY_BS58_ENSURE_LIMB(0UL);
+#pragma unroll
+    for (int limb = 0; limb < 9; ++limb)
+        VANITY_BS58_EMIT_LIMB(limb);
 
     ulong raw_leading_0s = 0UL;
     while (raw_leading_0s < 45UL)
     {
-        if (raw_leading_0s / 5UL >= limbs_done)
-            VANITY_BS58_ENSURE_LIMB(raw_leading_0s / 5UL);
         if (raw_base58[raw_leading_0s])
             break;
         raw_leading_0s++;
@@ -86,30 +85,48 @@ static __device__ __forceinline__ bool fd_base58_check_match_32_words(const uint
     ulong skip = raw_leading_0s - in_leading_0s;
     ulong encoded_length = 45UL - skip;
 
-    for (ulong i = 0UL; i < target_len; i++)
+    const uint *prefix_plan = (const uint *)prefixes;
+    uint candidates = prefix_plan[0];
+    if (candidates != 0U)
     {
-        ulong rb_idx = skip + i;
-        VANITY_BS58_ENSURE_LIMB(rb_idx / 5UL);
-        if (d_match_lut[raw_base58[rb_idx]] != target[i])
-            return false;
-    }
-
-    if (suffix_len > 0UL)
-    {
-        ulong tail_start = skip + encoded_length - suffix_len;
-        ulong last_limb = (skip + encoded_length - 1UL) / 5UL;
-        VANITY_BS58_ENSURE_LIMB(last_limb);
-        for (ulong i = 0UL; i < suffix_len; i++)
+        for (uint position = 0U;
+             position < 44U && position < (uint)encoded_length;
+             position++)
         {
-            if (d_match_lut[raw_base58[tail_start + i]] != suffix[i])
-                return false;
+            uint rb_idx = (uint)skip + position;
+            candidates &= prefix_plan[
+                1U + position * 58U
+                + (uint)d_match_lut[raw_base58[rb_idx]]];
+            if (candidates & prefix_plan[1U + 44U * 58U + position])
+                goto prefix_matched;
+            if (candidates == 0U) return false;
         }
+        return false;
+    }
+prefix_matched:
+
+    const uint *suffix_plan = (const uint *)suffixes;
+    candidates = suffix_plan[0];
+    if (candidates != 0U)
+    {
+        for (uint position = 0U;
+             position < 44U && position < (uint)encoded_length;
+             position++)
+        {
+            uint rb_idx = (uint)(skip + encoded_length - 1UL) - position;
+            candidates &= suffix_plan[
+                1U + position * 58U
+                + (uint)d_match_lut[raw_base58[rb_idx]]];
+            if (candidates & suffix_plan[1U + 44U * 58U + position])
+                return true;
+            if (candidates == 0U) return false;
+        }
+        return false;
     }
 
     return true;
 
     #undef VANITY_BS58_EMIT_LIMB
-    #undef VANITY_BS58_ENSURE_LIMB
 }
 
 #endif

--- a/kernels/opencl/base58.cl
+++ b/kernels/opencl/base58.cl
@@ -73,15 +73,19 @@ static ulong fd_base58_encode_32(const uchar *bytes, uchar *out, bool case_insen
     return encoded_length;
 }
 
+#define VANITY_MATCH_PLAN_WORDS (1UL + 44UL * 58UL + 44UL)
+
 /* Word-form fused base58 encode + prefix/suffix match with early rejection.
    `state[8]` is the SHA-256 digest as 8 native words (MSB-first); the two
-   byte-swaps cancel so binary[i] == state[i]. `target`/`suffix` are arrays
-   of canonical raw_base58 indices precomputed on the host; match_lut folds
-   raw_base58 values into the same canonical space. */
+   byte-swaps cancel so binary[i] == state[i]. Prefix and suffix plans contain
+   candidate bitmasks precomputed on the host; match_lut folds raw values into
+   the same canonical space. */
 static bool fd_base58_check_match_32_words(const uint state[8],
-                                           __global const uchar *target, ulong target_len,
-                                           __global const uchar *suffix, ulong suffix_len,
+                                           __global const uchar *prefixes, ulong prefix_count,
+                                           __global const uchar *suffixes, ulong suffix_count,
                                            __constant const uchar *match_lut) {
+    (void)prefix_count;
+    (void)suffix_count;
     /* Count leading zero bytes of the big-endian byte view of state[]. */
     ulong in_leading_0s = 0UL;
     for (int i = 0; i < 8; ++i) {
@@ -129,21 +133,41 @@ static bool fd_base58_check_match_32_words(const uint state[8],
     ulong skip = raw_leading_0s - in_leading_0s;
     ulong encoded_length = 45UL - skip;
 
-    for (ulong i = 0UL; i < target_len; i++) {
-        ulong rb_idx = skip + i;
-        VANITY_BS58_ENSURE_LIMB(rb_idx / 5UL);
-        if (match_lut[raw_base58[rb_idx]] != target[i])
-            return false;
-    }
-
-    if (suffix_len > 0UL) {
-        ulong tail_start = skip + encoded_length - suffix_len;
-        ulong last_limb = (skip + encoded_length - 1UL) / 5UL;
-        VANITY_BS58_ENSURE_LIMB(last_limb);
-        for (ulong i = 0UL; i < suffix_len; i++) {
-            if (match_lut[raw_base58[tail_start + i]] != suffix[i])
-                return false;
+    __global const uint *prefix_plan = (__global const uint *)prefixes;
+    uint candidates = prefix_plan[0];
+    if (candidates != 0U) {
+        for (uint position = 0U;
+             position < 44U && position < (uint)encoded_length;
+             position++) {
+            uint rb_idx = (uint)skip + position;
+            VANITY_BS58_ENSURE_LIMB((ulong)rb_idx / 5UL);
+            candidates &= prefix_plan[
+                1U + position * 58U
+                + (uint)match_lut[raw_base58[rb_idx]]];
+            if (candidates & prefix_plan[1U + 44U * 58U + position])
+                goto prefix_matched;
+            if (candidates == 0U) return false;
         }
+        return false;
+    }
+prefix_matched:
+
+    __global const uint *suffix_plan = (__global const uint *)suffixes;
+    candidates = suffix_plan[0];
+    if (candidates != 0U) {
+        for (uint position = 0U;
+             position < 44U && position < (uint)encoded_length;
+             position++) {
+            uint rb_idx = (uint)(skip + encoded_length - 1UL) - position;
+            VANITY_BS58_ENSURE_LIMB((ulong)rb_idx / 5UL);
+            candidates &= suffix_plan[
+                1U + position * 58U
+                + (uint)match_lut[raw_base58[rb_idx]]];
+            if (candidates & suffix_plan[1U + 44U * 58U + position])
+                return true;
+            if (candidates == 0U) return false;
+        }
+        return false;
     }
 
     return true;

--- a/kernels/opencl/host.c
+++ b/kernels/opencl/host.c
@@ -154,6 +154,8 @@ static cl_mem buf_copy(cl_context ctx, size_t sz, const void *host) {
     return m;
 }
 
+#define MATCH_PLAN_BYTES ((1u + 44u * 58u + 44u) * sizeof(uint32_t))
+
 /* Grow/shrink max_iters toward TARGET_LAUNCH_SEC based on last launch time. */
 static uint32_t adapt_iters(uint32_t cur, double elapsed, uint32_t lo, uint32_t hi) {
     if (elapsed <= 1e-6) return hi;
@@ -173,9 +175,9 @@ typedef struct {
     cl_command_queue queue;
     cl_program       program;
     cl_kernel        kernel;
-    cl_mem  seed, w0, sr7, w1, glyph, mlut, target, suffix, out, done, counts;
+    cl_mem  seed, w0, sr7, w1, glyph, mlut, prefix, suffix, out, done, counts;
     size_t  local, global;
-    uint32_t target_len, suffix_len;
+    uint32_t prefix_count, suffix_count;
     uint32_t max_iters;
     cl_event event;
     int      in_flight;
@@ -184,8 +186,8 @@ typedef struct {
 } GrindCtx;
 
 void *gpu_grind_init(int id, uint8_t *base, uint8_t *owner,
-                     uint8_t *target, uint64_t target_len,
-                     uint8_t *suffix, uint64_t suffix_len,
+                     uint8_t *prefixes, uint64_t prefix_count,
+                     uint8_t *suffixes, uint64_t suffix_count,
                      bool case_insensitive) {
     cl_platform_id plat;
     cl_device_id dev = select_device(id, &plat);
@@ -204,12 +206,12 @@ void *gpu_grind_init(int id, uint8_t *base, uint8_t *owner,
 
     c->local  = clamp_local(dev, GRIND_LOCAL);
     c->global = (size_t)compute_units(dev) * GRIND_WAVES * c->local;
-    c->target_len = (uint32_t)target_len;
-    c->suffix_len = (uint32_t)suffix_len;
+    c->prefix_count = (uint32_t)prefix_count;
+    c->suffix_count = (uint32_t)suffix_count;
     c->max_iters  = GRIND_ITERS_INIT;
     c->counts_host = (uint32_t *)malloc(c->global * sizeof(uint32_t));
 
-    /* Canonicalizing LUT + ASCII target/suffix -> canonical raw_base58 idx. */
+    /* Canonicalizing LUT; match plans arrive precomputed by the Rust host. */
     static const char alphabet_normal[59] =
         "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
     static const char alphabet_ci[59] =
@@ -221,19 +223,6 @@ void *gpu_grind_init(int id, uint8_t *base, uint8_t *owner,
         match_lut[i] = (uint8_t)i;
         for (int j = 0; j < i; ++j)
             if (alphabet[j] == alphabet[i]) { match_lut[i] = (uint8_t)j; break; }
-    }
-    uint8_t target_idx[64], suffix_idx[64];
-    for (uint64_t i = 0; i < target_len; ++i) {
-        uint8_t v = 255;
-        for (int k = 0; k < 58; ++k)
-            if ((uint8_t)alphabet[k] == target[i]) { v = match_lut[k]; break; }
-        target_idx[i] = v;
-    }
-    for (uint64_t i = 0; i < suffix_len; ++i) {
-        uint8_t v = 255;
-        for (int k = 0; k < 58; ++k)
-            if ((uint8_t)alphabet[k] == suffix[i]) { v = match_lut[k]; break; }
-        suffix_idx[i] = v;
     }
 
     /* SHA-256 block-1 schedule from owner[16..32] (loop invariant). */
@@ -280,8 +269,8 @@ void *gpu_grind_init(int id, uint8_t *base, uint8_t *owner,
     c->w1     = buf_copy(c->context, sizeof W1, W1);
     c->glyph  = buf_copy(c->context, sizeof glyph, glyph);
     c->mlut   = buf_copy(c->context, sizeof match_lut, match_lut);
-    c->target = buf_copy(c->context, target_len, target_idx);
-    c->suffix = buf_copy(c->context, suffix_len, suffix_idx);
+    c->prefix = buf_copy(c->context, MATCH_PLAN_BYTES, prefixes);
+    c->suffix = buf_copy(c->context, MATCH_PLAN_BYTES, suffixes);
     c->out    = clCreateBuffer(c->context, CL_MEM_WRITE_ONLY, 16, NULL, &err); CK(err, "buf out");
     c->done   = clCreateBuffer(c->context, CL_MEM_READ_WRITE, sizeof(cl_int), NULL, &err); CK(err, "buf done");
     c->counts = clCreateBuffer(c->context, CL_MEM_WRITE_ONLY, c->global * sizeof(cl_uint), NULL, &err); CK(err, "buf counts");
@@ -292,10 +281,10 @@ void *gpu_grind_init(int id, uint8_t *base, uint8_t *owner,
     CK(clSetKernelArg(c->kernel, 3, sizeof(cl_mem), &c->w1),     "arg w1");
     CK(clSetKernelArg(c->kernel, 4, sizeof(cl_mem), &c->glyph),  "arg glyph");
     CK(clSetKernelArg(c->kernel, 5, sizeof(cl_mem), &c->mlut),   "arg mlut");
-    CK(clSetKernelArg(c->kernel, 6, sizeof(cl_mem), &c->target), "arg target");
-    CK(clSetKernelArg(c->kernel, 7, sizeof(cl_uint), &c->target_len), "arg target_len");
+    CK(clSetKernelArg(c->kernel, 6, sizeof(cl_mem), &c->prefix), "arg prefix");
+    CK(clSetKernelArg(c->kernel, 7, sizeof(cl_uint), &c->prefix_count), "arg prefix_count");
     CK(clSetKernelArg(c->kernel, 8, sizeof(cl_mem), &c->suffix), "arg suffix");
-    CK(clSetKernelArg(c->kernel, 9, sizeof(cl_uint), &c->suffix_len), "arg suffix_len");
+    CK(clSetKernelArg(c->kernel, 9, sizeof(cl_uint), &c->suffix_count), "arg suffix_count");
     CK(clSetKernelArg(c->kernel, 10, sizeof(cl_mem), &c->out),   "arg out");
     CK(clSetKernelArg(c->kernel, 11, sizeof(cl_mem), &c->done),  "arg done");
     CK(clSetKernelArg(c->kernel, 12, sizeof(cl_mem), &c->counts),"arg counts");
@@ -353,7 +342,7 @@ void gpu_grind_destroy(void *opaque) {
     GrindCtx *c = (GrindCtx *)opaque;
     clFinish(c->queue);
     if (c->in_flight) clReleaseEvent(c->event);
-    cl_mem bufs[] = {c->seed,c->w0,c->sr7,c->w1,c->glyph,c->mlut,c->target,c->suffix,c->out,c->done,c->counts};
+    cl_mem bufs[] = {c->seed,c->w0,c->sr7,c->w1,c->glyph,c->mlut,c->prefix,c->suffix,c->out,c->done,c->counts};
     for (size_t i = 0; i < sizeof bufs / sizeof bufs[0]; ++i) clReleaseMemObject(bufs[i]);
     clReleaseKernel(c->kernel);
     clReleaseProgram(c->program);
@@ -372,7 +361,7 @@ typedef struct {
     cl_kernel        kernel;
     cl_mem  seed, mlut, prefix, suffix, out, done, counts, comb;
     size_t  local, global;
-    uint32_t prefix_len, suffix_len;
+    uint32_t prefix_count, suffix_count;
     uint32_t max_iters;
     cl_event event;
     int      in_flight;
@@ -384,8 +373,8 @@ typedef struct {
 #define COMB_NIELS_BYTES 160u
 #define COMB_TABLE_BYTES (52u * 16u * COMB_NIELS_BYTES)
 
-void *gpu_keypair_init(int id, uint8_t *prefix, uint64_t prefix_len,
-                       uint8_t *suffix, uint64_t suffix_len, bool case_insensitive) {
+void *gpu_keypair_init(int id, uint8_t *prefixes, uint64_t prefix_count,
+                       uint8_t *suffixes, uint64_t suffix_count, bool case_insensitive) {
     cl_platform_id plat;
     cl_device_id dev = select_device(id, &plat);
     cl_int err;
@@ -403,13 +392,13 @@ void *gpu_keypair_init(int id, uint8_t *prefix, uint64_t prefix_len,
 
     c->local  = clamp_local(dev, KP_LOCAL);
     c->global = (size_t)compute_units(dev) * KP_WAVES * c->local;
-    c->prefix_len = (uint32_t)prefix_len;
-    c->suffix_len = (uint32_t)suffix_len;
+    c->prefix_count = (uint32_t)prefix_count;
+    c->suffix_count = (uint32_t)suffix_count;
     c->max_iters = KP_ITERS_INIT;
     c->counts_host = (uint32_t *)malloc(c->global * sizeof(uint32_t));
 
-    /* Canonical base58 match indices + LUT (same scheme as gpu_grind_init /
-       CUDA gpu_keypair_init). Case folding lives in the LUT / indices. */
+    /* Canonical base58 LUT (same scheme as gpu_grind_init / CUDA
+       gpu_keypair_init). Match plans arrive precomputed by the Rust host. */
     static const char alphabet_normal[59] =
         "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
     static const char alphabet_ci[59] =
@@ -422,24 +411,10 @@ void *gpu_keypair_init(int id, uint8_t *prefix, uint64_t prefix_len,
         for (int j = 0; j < i; ++j)
             if (alphabet[j] == alphabet[i]) { match_lut[i] = (uint8_t)j; break; }
     }
-    uint8_t prefix_idx[64], suffix_idx[64];
-    for (uint64_t i = 0; i < prefix_len; ++i) {
-        uint8_t v = 255;
-        for (int k = 0; k < 58; ++k)
-            if ((uint8_t)alphabet[k] == prefix[i]) { v = match_lut[k]; break; }
-        prefix_idx[i] = v;
-    }
-    for (uint64_t i = 0; i < suffix_len; ++i) {
-        uint8_t v = 255;
-        for (int k = 0; k < 58; ++k)
-            if ((uint8_t)alphabet[k] == suffix[i]) { v = match_lut[k]; break; }
-        suffix_idx[i] = v;
-    }
-
     c->seed   = clCreateBuffer(c->context, CL_MEM_READ_ONLY, 32, NULL, &err); CK(err, "buf seed");
     c->mlut   = buf_copy(c->context, sizeof match_lut, match_lut);
-    c->prefix = buf_copy(c->context, prefix_len, prefix_idx);
-    c->suffix = buf_copy(c->context, suffix_len, suffix_idx);
+    c->prefix = buf_copy(c->context, MATCH_PLAN_BYTES, prefixes);
+    c->suffix = buf_copy(c->context, MATCH_PLAN_BYTES, suffixes);
     c->out    = clCreateBuffer(c->context, CL_MEM_WRITE_ONLY, 32, NULL, &err); CK(err, "buf out");
     c->done   = clCreateBuffer(c->context, CL_MEM_READ_WRITE, sizeof(cl_int), NULL, &err); CK(err, "buf done");
     c->counts = clCreateBuffer(c->context, CL_MEM_WRITE_ONLY, c->global * sizeof(cl_uint), NULL, &err); CK(err, "buf counts");
@@ -459,9 +434,9 @@ void *gpu_keypair_init(int id, uint8_t *prefix, uint64_t prefix_len,
 
     CK(clSetKernelArg(c->kernel, 1, sizeof(cl_mem), &c->mlut), "arg mlut");
     CK(clSetKernelArg(c->kernel, 2, sizeof(cl_mem), &c->prefix), "arg prefix");
-    CK(clSetKernelArg(c->kernel, 3, sizeof(cl_uint), &c->prefix_len), "arg prefix_len");
+    CK(clSetKernelArg(c->kernel, 3, sizeof(cl_uint), &c->prefix_count), "arg prefix_count");
     CK(clSetKernelArg(c->kernel, 4, sizeof(cl_mem), &c->suffix), "arg suffix");
-    CK(clSetKernelArg(c->kernel, 5, sizeof(cl_uint), &c->suffix_len), "arg suffix_len");
+    CK(clSetKernelArg(c->kernel, 5, sizeof(cl_uint), &c->suffix_count), "arg suffix_count");
     CK(clSetKernelArg(c->kernel, 6, sizeof(cl_mem), &c->out), "arg out");
     CK(clSetKernelArg(c->kernel, 7, sizeof(cl_mem), &c->done), "arg done");
     CK(clSetKernelArg(c->kernel, 8, sizeof(cl_mem), &c->counts), "arg counts");

--- a/kernels/opencl/keypair.cl
+++ b/kernels/opencl/keypair.cl
@@ -22,8 +22,8 @@
 __kernel void vanity_keypair_search(
     __global const uchar *host_seed,     /* 32 bytes */
     __constant const uchar *match_lut,   /* 58 */
-    __global const uchar *prefix, uint prefix_len,
-    __global const uchar *suffix, uint suffix_len,
+    __global const uchar *prefixes, uint prefix_count,
+    __global const uchar *suffixes, uint suffix_count,
     __global uchar *out,                 /* 32 bytes: matched seed */
     __global volatile int *done,
     __global uint *counts,
@@ -108,8 +108,8 @@ __kernel void vanity_keypair_search(
                                 | ((uint)pubkey[4*k + 3]      );
             }
 
-            if (fd_base58_check_match_32_words(pubkey_words, prefix, prefix_len,
-                                               suffix, suffix_len, match_lut)) {
+            if (fd_base58_check_match_32_words(pubkey_words, prefixes, prefix_count,
+                                               suffixes, suffix_count, match_lut)) {
                 if (atomic_cmpxchg(done, 0, 1) == 0)
                     for (int i = 0; i < 32; i++) out[i] = batch_seeds[j][i];
                 matched = j;

--- a/kernels/opencl/vanity.cl
+++ b/kernels/opencl/vanity.cl
@@ -79,8 +79,8 @@ __kernel void vanity_search(
     __constant const WORD *W1,           /* 64 */
     __constant const uchar *glyph,       /* 256 */
     __constant const uchar *match_lut,   /* 58 */
-    __global const uchar *target, uint target_len,
-    __global const uchar *suffix, uint suffix_len,
+    __global const uchar *prefixes, uint prefix_count,
+    __global const uchar *suffixes, uint suffix_count,
     __global uchar *out,                 /* 16 bytes: matched seed16 */
     __global volatile int *done,
     __global uint *counts,
@@ -122,8 +122,8 @@ __kernel void vanity_search(
 
         vanity_pubkey_sha256_words(seed_words, digest_words, W0_fixed, state_r7, W1);
 
-        if (fd_base58_check_match_32_words(digest_words, target, target_len,
-                                           suffix, suffix_len, match_lut)) {
+        if (fd_base58_check_match_32_words(digest_words, prefixes, prefix_count,
+                                           suffixes, suffix_count, match_lut)) {
             if (atomic_cmpxchg(done, 0, 1) == 0) {
                 for (int k = 0; k < 4; ++k) {
                     WORD w = seed_words[k];

--- a/kernels/vanity.cu
+++ b/kernels/vanity.cu
@@ -126,8 +126,8 @@ extern "C" void* gpu_grind_init(
     int id,
     uint8_t *base,
     uint8_t *owner,
-    uint8_t *target, uint64_t target_len,
-    uint8_t *suffix, uint64_t suffix_len,
+    uint8_t *prefixes, uint64_t prefix_count,
+    uint8_t *suffixes, uint64_t suffix_count,
     bool case_insensitive)
 {
     cudaSetDevice(id);
@@ -159,9 +159,11 @@ extern "C" void* gpu_grind_init(
 
     cudaStreamCreate(&ctx->stream);
 
-    // Buffer: [seed:32] [base:32] [owner:32] [target_len:8] [target:N] [suffix_len:8] [suffix:M] [out:16]
-    uint64_t buf_size = 32 + 32 + 32 + 8 + target_len + 8 + suffix_len + 16;
-    ctx->out_offset = 32 + 32 + 32 + 8 + target_len + 8 + suffix_len;
+    uint64_t prefix_bytes = VANITY_MATCH_PLAN_WORDS * sizeof(uint32_t);
+    uint64_t suffix_bytes = VANITY_MATCH_PLAN_WORDS * sizeof(uint32_t);
+    // Buffer: [seed:32] [base:32] [owner:32] [prefix_count:8] [prefixes] [suffix_count:8] [suffixes] [out:16]
+    uint64_t buf_size = 32 + 32 + 32 + 8 + prefix_bytes + 8 + suffix_bytes + 16;
+    ctx->out_offset = 32 + 32 + 32 + 8 + prefix_bytes + 8 + suffix_bytes;
 
     err = cudaMalloc((void**)&ctx->d_buffer, buf_size);
     if (err != cudaSuccess) {
@@ -169,9 +171,9 @@ extern "C" void* gpu_grind_init(
         exit(EXIT_FAILURE);
     }
 
-    /* Build canonicalization LUT (raw_base58 idx -> match key) and pre-
-       translate target/suffix from ASCII to those same canonical indices.
-       In normal mode the LUT is identity; in CI mode, raw indices that
+    /* Build the canonicalization LUT (raw_base58 index -> match key).
+       Match plans are already canonicalized by the Rust host. In normal mode
+       the LUT is identity; in CI mode, raw indices that
        encode the same character (e.g. both 9 and 33 -> 'a') fold to the
        lower index. */
     static const char alphabet_normal[59] =
@@ -191,30 +193,12 @@ extern "C" void* gpu_grind_init(
         }
     }
 
-    /* Translate ASCII target/suffix to canonical indices in host buffers. */
-    uint8_t target_idx[64];
-    uint8_t suffix_idx[64];
-    for (uint64_t i = 0; i < target_len; ++i) {
-        uint8_t v = 255;
-        for (int k = 0; k < 58; ++k) {
-            if ((uint8_t)alphabet[k] == target[i]) { v = host_match_lut[k]; break; }
-        }
-        target_idx[i] = v;
-    }
-    for (uint64_t i = 0; i < suffix_len; ++i) {
-        uint8_t v = 255;
-        for (int k = 0; k < 58; ++k) {
-            if ((uint8_t)alphabet[k] == suffix[i]) { v = host_match_lut[k]; break; }
-        }
-        suffix_idx[i] = v;
-    }
-
     cudaMemcpy(ctx->d_buffer + 32, base, 32, cudaMemcpyHostToDevice);
     cudaMemcpy(ctx->d_buffer + 64, owner, 32, cudaMemcpyHostToDevice);
-    cudaMemcpy(ctx->d_buffer + 96, &target_len, 8, cudaMemcpyHostToDevice);
-    if (target_len > 0) cudaMemcpy(ctx->d_buffer + 104, target_idx, target_len, cudaMemcpyHostToDevice);
-    cudaMemcpy(ctx->d_buffer + 104 + target_len, &suffix_len, 8, cudaMemcpyHostToDevice);
-    if (suffix_len > 0) cudaMemcpy(ctx->d_buffer + 104 + target_len + 8, suffix_idx, suffix_len, cudaMemcpyHostToDevice);
+    cudaMemcpy(ctx->d_buffer + 96, &prefix_count, 8, cudaMemcpyHostToDevice);
+    cudaMemcpy(ctx->d_buffer + 104, prefixes, prefix_bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(ctx->d_buffer + 104 + prefix_bytes, &suffix_count, 8, cudaMemcpyHostToDevice);
+    cudaMemcpy(ctx->d_buffer + 104 + prefix_bytes + 8, suffixes, suffix_bytes, cudaMemcpyHostToDevice);
 
     cudaMemcpyToSymbol(d_match_lut, host_match_lut, sizeof(host_match_lut));
 
@@ -352,13 +336,15 @@ vanity_search(uint8_t *buffer, uint64_t stride, unsigned long long max_cycles)
 {
     (void)stride;
     uint8_t *seed = buffer;
-    uint64_t target_len;
-    memcpy(&target_len, buffer + 96, 8);
-    uint8_t *target = buffer + 104;
-    uint64_t suffix_len;
-    memcpy(&suffix_len, buffer + 104 + target_len, 8);
-    uint8_t *suffix = buffer + 104 + target_len + 8;
-    uint8_t *out = (buffer + 104 + target_len + suffix_len + 8);
+    uint64_t prefix_count;
+    memcpy(&prefix_count, buffer + 96, 8);
+    uint8_t *prefixes = buffer + 104;
+    uint64_t prefix_bytes = VANITY_MATCH_PLAN_WORDS * sizeof(uint32_t);
+    uint64_t suffix_count;
+    memcpy(&suffix_count, buffer + 104 + prefix_bytes, 8);
+    uint8_t *suffixes = buffer + 104 + prefix_bytes + 8;
+    uint64_t suffix_bytes = VANITY_MATCH_PLAN_WORDS * sizeof(uint32_t);
+    uint8_t *out = suffixes + suffix_bytes;
 
     uint64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
 
@@ -420,7 +406,7 @@ vanity_search(uint8_t *buffer, uint64_t stride, unsigned long long max_cycles)
 
         vanity_pubkey_sha256_words(seed_words, digest_words);
 
-        if (fd_base58_check_match_32_words(digest_words, target, target_len, suffix, suffix_len))
+        if (fd_base58_check_match_32_words(digest_words, prefixes, prefix_count, suffixes, suffix_count))
         {
             if (atomicMax(&done, 1) == 0)
             {

--- a/kernels/vanity.h
+++ b/kernels/vanity.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include "utils.h"
 
-extern "C" void* gpu_grind_init(int id, uint8_t *base, uint8_t *owner, uint8_t *target, uint64_t target_len, uint8_t *suffix, uint64_t suffix_len, bool case_insensitive);
+extern "C" void* gpu_grind_init(int id, uint8_t *base, uint8_t *owner, uint8_t *prefixes, uint64_t prefix_count, uint8_t *suffixes, uint64_t suffix_count, bool case_insensitive);
 extern "C" void  gpu_grind_launch(void *ctx, uint8_t *seed);
 extern "C" int   gpu_grind_query(void *ctx);
 extern "C" void  gpu_grind_read(void *ctx, uint8_t *out);

--- a/kernels/vanity_keypair.cu
+++ b/kernels/vanity_keypair.cu
@@ -31,8 +31,8 @@ typedef struct {
 
 extern "C" void* gpu_keypair_init(
     int id,
-    uint8_t *prefix, uint64_t prefix_len,
-    uint8_t *suffix, uint64_t suffix_len,
+    uint8_t *prefixes, uint64_t prefix_count,
+    uint8_t *suffixes, uint64_t suffix_count,
     bool case_insensitive)
 {
     cudaSetDevice(id);
@@ -62,9 +62,11 @@ extern "C" void* gpu_keypair_init(
 
     cudaStreamCreate(&ctx->stream);
 
-    // Buffer: [seed:32] [prefix_len:8] [prefix:N] [suffix_len:8] [suffix:M] [out:32]
-    uint64_t buf_size = 32 + 8 + prefix_len + 8 + suffix_len + 32;
-    ctx->out_offset = 32 + 8 + prefix_len + 8 + suffix_len;
+    uint64_t prefix_bytes = VANITY_MATCH_PLAN_WORDS * sizeof(uint32_t);
+    uint64_t suffix_bytes = VANITY_MATCH_PLAN_WORDS * sizeof(uint32_t);
+    // Buffer: [seed:32] [prefix_count:8] [prefixes] [suffix_count:8] [suffixes] [out:32]
+    uint64_t buf_size = 32 + 8 + prefix_bytes + 8 + suffix_bytes + 32;
+    ctx->out_offset = 32 + 8 + prefix_bytes + 8 + suffix_bytes;
 
     err = cudaMalloc((void**)&ctx->d_buffer, buf_size);
     if (err != cudaSuccess) {
@@ -72,7 +74,7 @@ extern "C" void* gpu_keypair_init(
         exit(EXIT_FAILURE);
     }
 
-    /* Canonical base58 match indices + LUT (same scheme as gpu_grind_init). */
+    /* Canonical base58 LUT; match plans arrive precomputed by the Rust host. */
     {
         static const char alphabet_normal[59] =
             "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
@@ -91,29 +93,12 @@ extern "C" void* gpu_keypair_init(
             }
         }
 
-        uint8_t prefix_idx[64];
-        uint8_t suffix_idx[64];
-        for (uint64_t i = 0; i < prefix_len; ++i) {
-            uint8_t v = 255;
-            for (int k = 0; k < 58; ++k) {
-                if ((uint8_t)alphabet[k] == prefix[i]) { v = host_match_lut[k]; break; }
-            }
-            prefix_idx[i] = v;
-        }
-        for (uint64_t i = 0; i < suffix_len; ++i) {
-            uint8_t v = 255;
-            for (int k = 0; k < 58; ++k) {
-                if ((uint8_t)alphabet[k] == suffix[i]) { v = host_match_lut[k]; break; }
-            }
-            suffix_idx[i] = v;
-        }
-
         uint64_t off = 32;
-        cudaMemcpy(ctx->d_buffer + off, &prefix_len, 8, cudaMemcpyHostToDevice); off += 8;
-        if (prefix_len > 0) cudaMemcpy(ctx->d_buffer + off, prefix_idx, prefix_len, cudaMemcpyHostToDevice);
-        off += prefix_len;
-        cudaMemcpy(ctx->d_buffer + off, &suffix_len, 8, cudaMemcpyHostToDevice); off += 8;
-        if (suffix_len > 0) cudaMemcpy(ctx->d_buffer + off, suffix_idx, suffix_len, cudaMemcpyHostToDevice);
+        cudaMemcpy(ctx->d_buffer + off, &prefix_count, 8, cudaMemcpyHostToDevice); off += 8;
+        cudaMemcpy(ctx->d_buffer + off, prefixes, prefix_bytes, cudaMemcpyHostToDevice);
+        off += prefix_bytes;
+        cudaMemcpy(ctx->d_buffer + off, &suffix_count, 8, cudaMemcpyHostToDevice); off += 8;
+        cudaMemcpy(ctx->d_buffer + off, suffixes, suffix_bytes, cudaMemcpyHostToDevice);
 
         cudaMemcpyToSymbol(d_match_lut, host_match_lut, sizeof(host_match_lut));
     }
@@ -176,22 +161,24 @@ extern "C" void gpu_keypair_destroy(void *opaque)
     free(ctx);
 }
 
-// ─── kernel (unchanged) ─────────────────────────────────────────────────────
+// ─── kernel ─────────────────────────────────────────────────────────────────
 
 static __global__ void __launch_bounds__(KP_MAX_THREADS)
 vanity_keypair_search(uint8_t *buffer, uint64_t stride, unsigned long long max_cycles)
 {
     uint8_t *host_seed = buffer;
 
-    uint64_t prefix_len;
-    memcpy(&prefix_len, buffer + 32, 8);
-    uint8_t *prefix = buffer + 40;
+    uint64_t prefix_count;
+    memcpy(&prefix_count, buffer + 32, 8);
+    uint8_t *prefixes = buffer + 40;
+    uint64_t prefix_bytes = VANITY_MATCH_PLAN_WORDS * sizeof(uint32_t);
 
-    uint64_t suffix_len;
-    memcpy(&suffix_len, buffer + 40 + prefix_len, 8);
-    uint8_t *suffix = buffer + 40 + prefix_len + 8;
+    uint64_t suffix_count;
+    memcpy(&suffix_count, buffer + 40 + prefix_bytes, 8);
+    uint8_t *suffixes = buffer + 40 + prefix_bytes + 8;
+    uint64_t suffix_bytes = VANITY_MATCH_PLAN_WORDS * sizeof(uint32_t);
 
-    uint8_t *out = suffix + suffix_len;
+    uint8_t *out = suffixes + suffix_bytes;
 
     uint64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
 
@@ -233,7 +220,7 @@ vanity_keypair_search(uint8_t *buffer, uint64_t stride, unsigned long long max_c
         md.state[6] = UINT64_C(0x1f83d9abfb41bd6b);
         md.state[7] = UINT64_C(0x5be0cd19137e2179);
 
-        #pragma unroll
+#pragma unroll
         for (int i = 0; i < 32; i++) {
             md.buf[i] = seed[i];
         }
@@ -257,7 +244,7 @@ vanity_keypair_search(uint8_t *buffer, uint64_t stride, unsigned long long max_c
                             | ((uint)pubkey[4*k + 3]      );
         }
 
-        if (fd_base58_check_match_32_words(pubkey_words, prefix, prefix_len, suffix, suffix_len))
+        if (fd_base58_check_match_32_words(pubkey_words, prefixes, prefix_count, suffixes, suffix_count))
         {
             if (atomicMax(&kp_done, 1) == 0) {
                 memcpy(out, seed, 32);

--- a/kernels/vanity_keypair.h
+++ b/kernels/vanity_keypair.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-extern "C" void* gpu_keypair_init(int id, uint8_t *prefix, uint64_t prefix_len, uint8_t *suffix, uint64_t suffix_len, bool case_insensitive);
+extern "C" void* gpu_keypair_init(int id, uint8_t *prefixes, uint64_t prefix_count, uint8_t *suffixes, uint64_t suffix_count, bool case_insensitive);
 extern "C" void  gpu_keypair_launch(void *ctx, uint8_t *seed);
 extern "C" int   gpu_keypair_query(void *ctx);
 extern "C" void  gpu_keypair_read(void *ctx, uint8_t *out);

--- a/src/fast/check_match.rs
+++ b/src/fast/check_match.rs
@@ -49,18 +49,21 @@ pub fn match_lut(case_insensitive: bool) -> &'static [u8; 58] {
     }
 }
 
+struct Pattern {
+    indices: [u8; MAX_PATTERN_LEN],
+    len: u8,
+}
+
 pub struct MatchTarget {
-    prefix_idx: [u8; MAX_PATTERN_LEN],
-    prefix_len: u8,
-    suffix_idx: [u8; MAX_PATTERN_LEN],
-    suffix_len: u8,
+    prefixes: Vec<Pattern>,
+    suffixes: Vec<Pattern>,
     match_lut: &'static [u8; 58],
 }
 
 impl MatchTarget {
     pub fn new(
-        prefix: &str,
-        suffix: &str,
+        prefixes: &[String],
+        suffixes: &[String],
         case_insensitive: bool,
     ) -> Self {
         let alphabet = if case_insensitive {
@@ -70,23 +73,21 @@ impl MatchTarget {
         };
         let lut = match_lut(case_insensitive);
 
-        let mut prefix_idx = [0u8; MAX_PATTERN_LEN];
-        debug_assert!(prefix.len() <= MAX_PATTERN_LEN);
-        for (i, &b) in prefix.as_bytes().iter().enumerate() {
-            prefix_idx[i] = char_to_canonical(b, alphabet, lut);
-        }
-
-        let mut suffix_idx = [0u8; MAX_PATTERN_LEN];
-        debug_assert!(suffix.len() <= MAX_PATTERN_LEN);
-        for (i, &b) in suffix.as_bytes().iter().enumerate() {
-            suffix_idx[i] = char_to_canonical(b, alphabet, lut);
-        }
+        let encode = |pattern: &String| {
+            let mut indices = [0u8; MAX_PATTERN_LEN];
+            debug_assert!(pattern.len() <= MAX_PATTERN_LEN);
+            for (i, &byte) in pattern.as_bytes().iter().enumerate() {
+                indices[i] = char_to_canonical(byte, alphabet, lut);
+            }
+            Pattern {
+                indices,
+                len: pattern.len() as u8,
+            }
+        };
 
         Self {
-            prefix_idx,
-            prefix_len: prefix.len() as u8,
-            suffix_idx,
-            suffix_len: suffix.len() as u8,
+            prefixes: prefixes.iter().map(encode).collect(),
+            suffixes: suffixes.iter().map(encode).collect(),
             match_lut: lut,
         }
     }
@@ -95,11 +96,9 @@ impl MatchTarget {
     pub fn matches(&self, bytes: &[u8; 32]) -> bool {
         check_match_32(
             bytes,
-            &self.prefix_idx,
-            self.prefix_len,
-            &self.suffix_idx,
-            self.suffix_len,
-            &self.match_lut,
+            &self.prefixes,
+            &self.suffixes,
+            self.match_lut,
         )
     }
 }
@@ -148,10 +147,8 @@ fn ensure_limb(
 #[inline]
 fn check_match_32(
     bytes: &[u8; 32],
-    prefix_idx: &[u8; MAX_PATTERN_LEN],
-    prefix_len: u8,
-    suffix_idx: &[u8; MAX_PATTERN_LEN],
-    suffix_len: u8,
+    prefixes: &[Pattern],
+    suffixes: &[Pattern],
     match_lut: &[u8; 58],
 ) -> bool {
     let mut in_leading_0s = 0usize;
@@ -160,9 +157,9 @@ fn check_match_32(
     }
 
     let mut binary = [0u32; BINARY_SZ_32];
-    for i in 0..BINARY_SZ_32 {
+    for (i, word) in binary.iter_mut().enumerate() {
         let o = i * 4;
-        binary[i] = u32::from_be_bytes([
+        *word = u32::from_be_bytes([
             bytes[o],
             bytes[o + 1],
             bytes[o + 2],
@@ -205,23 +202,40 @@ fn check_match_32(
     let skip = raw_leading_0s - in_leading_0s;
     let encoded_length = RAW58_SZ_32 - skip;
 
-    for i in 0..prefix_len as usize {
-        let target = prefix_idx[i];
-        let rb_idx = skip + i;
-        ensure_limb(
-            &intermediate,
-            &mut raw_base58,
-            &mut limbs_done,
-            rb_idx / 5,
-        );
-        if match_lut[raw_base58[rb_idx] as usize] != target {
+    if !prefixes.is_empty() {
+        let mut any_prefix = false;
+        for pattern in prefixes {
+            let pattern_len = pattern.len as usize;
+            if pattern_len > encoded_length {
+                continue;
+            }
+            let mut matched = true;
+            for i in 0..pattern_len {
+                let rb_idx = skip + i;
+                ensure_limb(
+                    &intermediate,
+                    &mut raw_base58,
+                    &mut limbs_done,
+                    rb_idx / 5,
+                );
+                if match_lut[raw_base58[rb_idx] as usize]
+                    != pattern.indices[i]
+                {
+                    matched = false;
+                    break;
+                }
+            }
+            if matched {
+                any_prefix = true;
+                break;
+            }
+        }
+        if !any_prefix {
             return false;
         }
     }
 
-    if suffix_len > 0 {
-        let suffix_len = suffix_len as usize;
-        let tail_start = skip + encoded_length - suffix_len;
+    if !suffixes.is_empty() {
         let last_limb = (skip + encoded_length - 1) / 5;
         ensure_limb(
             &intermediate,
@@ -229,12 +243,29 @@ fn check_match_32(
             &mut limbs_done,
             last_limb,
         );
-        for i in 0..suffix_len {
-            let target = suffix_idx[i];
-            if match_lut[raw_base58[tail_start + i] as usize] != target
-            {
-                return false;
+        let mut any_suffix = false;
+        for pattern in suffixes {
+            let pattern_len = pattern.len as usize;
+            if pattern_len > encoded_length {
+                continue;
             }
+            let tail_start = skip + encoded_length - pattern_len;
+            let mut matched = true;
+            for i in 0..pattern_len {
+                if match_lut[raw_base58[tail_start + i] as usize]
+                    != pattern.indices[i]
+                {
+                    matched = false;
+                    break;
+                }
+            }
+            if matched {
+                any_suffix = true;
+                break;
+            }
+        }
+        if !any_suffix {
+            return false;
         }
     }
 
@@ -275,7 +306,11 @@ mod tests {
 
     #[test]
     fn agrees_with_full_encode_random() {
-        let target = MatchTarget::new("zz", "LM", false);
+        let target = MatchTarget::new(
+            &["zz".to_string()],
+            &["LM".to_string()],
+            false,
+        );
         for i in 0u32..5000 {
             let h: [u8; 64] = Sha512::digest(i.to_le_bytes()).into();
             let seed: [u8; 32] = h[..32].try_into().unwrap();
@@ -290,7 +325,7 @@ mod tests {
 
     #[test]
     fn agrees_with_full_encode_ci() {
-        let target = MatchTarget::new("mithriL", "", true);
+        let target = MatchTarget::new(&["mithriL".to_string()], &[], true);
         for i in 0u32..2000 {
             let h: [u8; 64] =
                 Sha512::digest((i ^ 0xdeadbeef).to_le_bytes()).into();
@@ -315,8 +350,43 @@ mod tests {
             let bytes = fd_bs58::decode_32(key).unwrap();
             let prefix = &key[..key.len().min(3)];
             let suffix = &key[key.len().saturating_sub(2)..];
-            let target = MatchTarget::new(prefix, suffix, false);
+            let target = MatchTarget::new(
+                &[prefix.to_string()],
+                &[suffix.to_string()],
+                false,
+            );
             assert!(target.matches(&bytes), "{key}");
         }
+    }
+
+    #[test]
+    fn matches_any_prefix_and_any_suffix() {
+        let key = "XkCriyrNwS3G4rzAXtG5B1nnvb5Ka1JtCku93VqeKAr";
+        let bytes = fd_bs58::decode_32(key).unwrap();
+        let target = MatchTarget::new(
+            &["sun".to_string(), "XkC".to_string()],
+            &["mint".to_string(), "KAr".to_string()],
+            false,
+        );
+        assert!(target.matches(&bytes));
+
+        let wrong_suffix = MatchTarget::new(
+            &["sun".to_string(), "XkC".to_string()],
+            &["mint".to_string(), "moon".to_string()],
+            false,
+        );
+        assert!(!wrong_suffix.matches(&bytes));
+    }
+
+    #[test]
+    fn matches_multiple_case_insensitive_patterns() {
+        let key = "XkCriyrNwS3G4rzAXtG5B1nnvb5Ka1JtCku93VqeKAr";
+        let bytes = fd_bs58::decode_32(key).unwrap();
+        let target = MatchTarget::new(
+            &["sun".to_string(), "xkc".to_string()],
+            &["mint".to_string(), "kar".to_string()],
+            true,
+        );
+        assert!(target.matches(&bytes));
     }
 }

--- a/src/fast/mod.rs
+++ b/src/fast/mod.rs
@@ -326,13 +326,13 @@ pub fn backend_name() -> &'static str {
 /// Call [`reset_grind`] first if coordinating with a GPU thread that shares
 /// these counters via [`add_attempts`] / [`note_found`] / [`is_done`].
 pub fn run_cpu_workers(
-    prefix: &'static str,
-    suffix: &'static str,
+    prefixes: &[String],
+    suffixes: &[String],
     case_insensitive: bool,
     num_cpus: u32,
     count: u32,
 ) {
-    let target = MatchTarget::new(prefix, suffix, case_insensitive);
+    let target = MatchTarget::new(prefixes, suffixes, case_insensitive);
 
     (0..num_cpus).into_par_iter().for_each(|_| {
         #[cfg(target_arch = "x86_64")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@ use ed25519_dalek::SigningKey;
 use num_bigint::BigUint;
 use num_format::{Locale, ToFormattedString};
 use num_traits::{One, ToPrimitive, Zero};
-use rand;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use sha2::{Digest, Sha256};
 use solana_pubkey::Pubkey;
@@ -47,6 +46,12 @@ pub enum Command {
 }
 
 #[derive(Debug, Parser)]
+#[command(group(
+    clap::ArgGroup::new("target")
+        .required(true)
+        .multiple(true)
+        .args(["prefix", "suffix"])
+))]
 pub struct GrindArgs {
     /// The pubkey that will be the signer for the CreateAccountWithSeed instruction
     #[clap(long, value_parser = parse_pubkey)]
@@ -56,12 +61,13 @@ pub struct GrindArgs {
     #[clap(long, value_parser = parse_pubkey)]
     pub owner: Pubkey,
 
-    /// The target prefix for the pubkey
-    #[clap(long)]
-    pub prefix: Option<String>,
+    /// Target prefixes for the pubkey (repeat or separate with commas)
+    #[clap(long, value_delimiter = ',', value_parser = parse_bs58_pattern)]
+    pub prefix: Vec<String>,
 
-    #[clap(long)]
-    pub suffix: Option<String>,
+    /// Target suffixes for the pubkey (repeat or separate with commas)
+    #[clap(long, value_delimiter = ',', value_parser = parse_bs58_pattern)]
+    pub suffix: Vec<String>,
 
     /// Whether user cares about the case of the pubkey
     #[clap(long, default_value_t = false)]
@@ -82,14 +88,20 @@ pub struct GrindArgs {
 }
 
 #[derive(Debug, Parser)]
+#[command(group(
+    clap::ArgGroup::new("target")
+        .required(true)
+        .multiple(true)
+        .args(["prefix", "suffix"])
+))]
 pub struct GrindKeypairArgs {
-    /// The target prefix for the pubkey
-    #[clap(long)]
-    pub prefix: Option<String>,
+    /// Target prefixes for the pubkey (repeat or separate with commas)
+    #[clap(long, value_delimiter = ',', value_parser = parse_bs58_pattern)]
+    pub prefix: Vec<String>,
 
-    /// The target suffix for the pubkey
-    #[clap(long)]
-    pub suffix: Option<String>,
+    /// Target suffixes for the pubkey (repeat or separate with commas)
+    #[clap(long, value_delimiter = ',', value_parser = parse_bs58_pattern)]
+    pub suffix: Vec<String>,
 
     /// Whether user cares about the case of the pubkey
     #[clap(long, default_value_t = false)]
@@ -198,6 +210,180 @@ fn done(target: u32) -> bool {
 // ─── bs58 probability (from cavemanloverboy/bs58p) ──────────────────────────
 
 const BS58_ALPHABET: &str = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const MAX_BS58_ADDRESS_LEN: usize = 44;
+#[cfg(feature = "gpu")]
+const MAX_GPU_PATTERNS: usize = 32;
+#[cfg(feature = "gpu")]
+const MATCH_PLAN_MASKS: usize = MAX_BS58_ADDRESS_LEN * 58;
+#[cfg(feature = "gpu")]
+const MATCH_PLAN_WORDS: usize = 1 + MATCH_PLAN_MASKS + MAX_BS58_ADDRESS_LEN;
+
+#[derive(Debug)]
+struct SearchTargets {
+    prefixes: Vec<String>,
+    suffixes: Vec<String>,
+    case_insensitive: bool,
+}
+
+impl SearchTargets {
+    fn new(
+        prefixes: Vec<String>,
+        suffixes: Vec<String>,
+        case_insensitive: bool,
+    ) -> Self {
+        Self {
+            prefixes: normalize_patterns(prefixes, true, case_insensitive),
+            suffixes: normalize_patterns(suffixes, false, case_insensitive),
+            case_insensitive,
+        }
+    }
+
+    fn probability(&self) -> f64 {
+        let mut probability = 0.0;
+        if self.prefixes.is_empty() {
+            for suffix in &self.suffixes {
+                probability +=
+                    bs58_probability("", suffix, self.case_insensitive);
+            }
+        } else if self.suffixes.is_empty() {
+            for prefix in &self.prefixes {
+                probability +=
+                    bs58_probability(prefix, "", self.case_insensitive);
+            }
+        } else {
+            for prefix in &self.prefixes {
+                for suffix in &self.suffixes {
+                    probability += bs58_probability(
+                        prefix,
+                        suffix,
+                        self.case_insensitive,
+                    );
+                }
+            }
+        }
+        probability.min(1.0)
+    }
+
+    fn expected_attempts(&self) -> f64 {
+        let probability = self.probability();
+        if probability <= 0.0 {
+            f64::INFINITY
+        } else {
+            1.0 / probability
+        }
+    }
+
+    fn matches(&self, pubkey: &str) -> bool {
+        let prefix_matches = self.prefixes.is_empty()
+            || self.prefixes.iter().any(|prefix| {
+                matches_pattern(pubkey, prefix, true, self.case_insensitive)
+            });
+        prefix_matches
+            && (self.suffixes.is_empty()
+                || self.suffixes.iter().any(|suffix| {
+                    matches_pattern(
+                        pubkey,
+                        suffix,
+                        false,
+                        self.case_insensitive,
+                    )
+                }))
+    }
+
+    #[cfg(feature = "gpu")]
+    fn packed_prefixes(&self) -> Vec<u32> {
+        build_match_plan(&self.prefixes, true, self.case_insensitive)
+    }
+
+    #[cfg(feature = "gpu")]
+    fn packed_suffixes(&self) -> Vec<u32> {
+        build_match_plan(&self.suffixes, false, self.case_insensitive)
+    }
+
+    #[cfg(feature = "gpu")]
+    fn validate_gpu_pattern_count(&self) -> Result<(), String> {
+        if self.prefixes.len() > MAX_GPU_PATTERNS
+            || self.suffixes.len() > MAX_GPU_PATTERNS
+        {
+            return Err(format!(
+                "GPU searches support at most {MAX_GPU_PATTERNS} non-redundant prefixes and suffixes"
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn normalize_patterns(
+    patterns: Vec<String>,
+    prefix: bool,
+    case_insensitive: bool,
+) -> Vec<String> {
+    let mut patterns: Vec<String> = patterns
+        .into_iter()
+        .map(|pattern| {
+            maybe_bs58_aware_lowercase(&pattern, case_insensitive)
+        })
+        .collect();
+    patterns.sort_by_key(String::len);
+
+    let mut normalized: Vec<String> = Vec::with_capacity(patterns.len());
+    for pattern in patterns {
+        let redundant = normalized.iter().any(|existing| {
+            if prefix {
+                pattern.starts_with(existing)
+            } else {
+                pattern.ends_with(existing)
+            }
+        });
+        if !redundant {
+            normalized.push(pattern);
+        }
+    }
+    normalized
+}
+
+#[cfg(feature = "gpu")]
+fn build_match_plan(
+    patterns: &[String],
+    prefix: bool,
+    case_insensitive: bool,
+) -> Vec<u32> {
+    debug_assert!(
+        patterns.len() <= MAX_GPU_PATTERNS,
+        "GPU searches support at most {MAX_GPU_PATTERNS} prefixes and suffixes"
+    );
+
+    let alphabet = if case_insensitive {
+        b"123456789abcdefghjkLmnpqrstuvwxyzabcdefghijkmnopqrstuvwxyz"
+    } else {
+        BS58_ALPHABET.as_bytes()
+    };
+    let mut plan = vec![0u32; MATCH_PLAN_WORDS];
+    plan[0] = match patterns.len() {
+        0 => 0,
+        MAX_GPU_PATTERNS => u32::MAX,
+        count => (1u32 << count) - 1,
+    };
+    for (pattern_index, pattern) in patterns.iter().enumerate() {
+        let candidate = 1u32 << pattern_index;
+        let bytes: Box<dyn Iterator<Item = u8>> = if prefix {
+            Box::new(pattern.bytes())
+        } else {
+            Box::new(pattern.bytes().rev())
+        };
+        for (position, byte) in bytes.enumerate() {
+            let symbol = alphabet
+                .iter()
+                .position(|&candidate| candidate == byte)
+                .unwrap();
+            plan[1 + position * 58 + symbol] |= candidate;
+            if position + 1 == pattern.len() {
+                plan[1 + MATCH_PLAN_MASKS + position] |= candidate;
+            }
+        }
+    }
+    plan
+}
 
 fn bs58_pure_prefix_suffix_prob(prefix: &str, suffix: &str, n_bytes: usize) -> f64 {
     if prefix.is_empty() && suffix.is_empty() {
@@ -268,7 +454,7 @@ fn bs58_ci_position_factor(pattern_c: char) -> f64 {
             if pattern_c == 'L' {
                 a == 'L'
             } else {
-                a.to_ascii_lowercase() == pattern_c.to_ascii_lowercase()
+                a.eq_ignore_ascii_case(&pattern_c)
             }
         })
         .count();
@@ -299,15 +485,6 @@ fn bs58_probability(prefix: &str, suffix: &str, case_insensitive: bool) -> f64 {
         prob * bs58_ci_factor(prefix, suffix)
     } else {
         prob
-    }
-}
-
-fn expected_attempts(prefix: &str, suffix: &str, case_insensitive: bool) -> f64 {
-    let p = bs58_probability(prefix, suffix, case_insensitive);
-    if p <= 0.0 {
-        f64::INFINITY
-    } else {
-        1.0 / p
     }
 }
 
@@ -493,16 +670,26 @@ pub fn deploy_with_max_program_len_with_seed(
 
 fn grind(mut args: GrindArgs) {
     maybe_update_num_cpus(&mut args.num_cpus);
-    let prefix = get_validated_bs58("prefix", &args.prefix, args.case_insensitive);
-    let suffix = get_validated_bs58("suffix", &args.suffix, args.case_insensitive);
+    let targets = Arc::new(SearchTargets::new(
+        std::mem::take(&mut args.prefix),
+        std::mem::take(&mut args.suffix),
+        args.case_insensitive,
+    ));
+    #[cfg(feature = "gpu")]
+    if args.num_gpus > 0 {
+        targets.validate_gpu_pattern_count().unwrap_or_else(|error| {
+            eprintln!("error: {error}");
+            std::process::exit(2);
+        });
+    }
 
-    let expected = expected_attempts(prefix, suffix, args.case_insensitive);
-    let prob = bs58_probability(prefix, suffix, args.case_insensitive);
+    let expected = targets.expected_attempts();
+    let prob = targets.probability();
     #[cfg(feature = "gpu")]
     eprintln!("using {} cpus, {} gpus", args.num_cpus, args.num_gpus);
     #[cfg(not(feature = "gpu"))]
     eprintln!("using {} cpus", args.num_cpus);
-    let target_label = format_target_label(prefix, suffix);
+    let target_label = format_target_label(&targets);
     eprintln!(
         "target: {} | probability: {:.6e} | expected: {} attempts",
         target_label,
@@ -519,10 +706,13 @@ fn grind(mut args: GrindArgs) {
         let base = args.base;
         let owner = args.owner;
         let ci = args.case_insensitive;
+        let targets = Arc::clone(&targets);
         Some(
             thread::Builder::new()
                 .name("gpu_mgr".into())
                 .spawn(move || {
+                    let prefixes = targets.packed_prefixes();
+                    let suffixes = targets.packed_suffixes();
                     let mut contexts = Vec::with_capacity(num_gpus as usize);
                     for id in 0..num_gpus {
                         let ctx = unsafe {
@@ -530,10 +720,10 @@ fn grind(mut args: GrindArgs) {
                                 id as i32,
                                 base.as_ref().as_ptr(),
                                 owner.as_ref().as_ptr(),
-                                prefix.as_ptr(),
-                                prefix.len() as u64,
-                                suffix.as_ptr(),
-                                suffix.len() as u64,
+                                prefixes.as_ptr().cast(),
+                                targets.prefixes.len() as u64,
+                                suffixes.as_ptr().cast(),
+                                targets.suffixes.len() as u64,
                                 ci,
                             )
                         };
@@ -584,10 +774,8 @@ fn grind(mut args: GrindArgs) {
                                 .finalize()
                                 .into();
                             let out_str = fd_bs58::encode_32(reconstructed);
-                            let out_str_check = maybe_bs58_aware_lowercase(&out_str, ci);
 
-                            if out_str_check.starts_with(prefix) && out_str_check.ends_with(suffix)
-                            {
+                            if targets.matches(&out_str) {
                                 eprintln!(
                                     "\r\x1b[Kgpu {} match: {} in {:.3}s",
                                     i, &out_str, time_sec
@@ -678,7 +866,7 @@ fn grind(mut args: GrindArgs) {
                 local_batch -= 4096;
             }
 
-            if matches_target(&pubkey, prefix, suffix, args.case_insensitive) {
+            if targets.matches(&pubkey) {
                 if local_batch > 0 {
                     TOTAL_ATTEMPTS.fetch_add(local_batch, Ordering::Relaxed);
                     local_batch = 0;
@@ -724,11 +912,21 @@ fn grind(mut args: GrindArgs) {
 
 fn grind_keypair(mut args: GrindKeypairArgs) {
     maybe_update_num_cpus(&mut args.num_cpus);
-    let prefix = get_validated_bs58("prefix", &args.prefix, args.case_insensitive);
-    let suffix = get_validated_bs58("suffix", &args.suffix, args.case_insensitive);
+    let targets = Arc::new(SearchTargets::new(
+        std::mem::take(&mut args.prefix),
+        std::mem::take(&mut args.suffix),
+        args.case_insensitive,
+    ));
+    #[cfg(feature = "gpu")]
+    if args.num_gpus > 0 {
+        targets.validate_gpu_pattern_count().unwrap_or_else(|error| {
+            eprintln!("error: {error}");
+            std::process::exit(2);
+        });
+    }
 
-    let expected = expected_attempts(prefix, suffix, args.case_insensitive);
-    let prob = bs58_probability(prefix, suffix, args.case_insensitive);
+    let expected = targets.expected_attempts();
+    let prob = targets.probability();
     #[cfg(feature = "gpu")]
     eprintln!(
         "using {} cpus, {} gpus (cpu backend: {})",
@@ -742,7 +940,7 @@ fn grind_keypair(mut args: GrindKeypairArgs) {
         args.num_cpus,
         fast::backend_name()
     );
-    let target_label = format_target_label(prefix, suffix);
+    let target_label = format_target_label(&targets);
     eprintln!(
         "target: {} | probability: {:.6e} | expected: {} attempts",
         target_label,
@@ -777,19 +975,22 @@ fn grind_keypair(mut args: GrindKeypairArgs) {
     let gpu_thread = if args.num_gpus > 0 {
         let num_gpus = args.num_gpus;
         let ci = args.case_insensitive;
+        let targets = Arc::clone(&targets);
         Some(
             thread::Builder::new()
                 .name("gpu_mgr".into())
                 .spawn(move || {
+                    let prefixes = targets.packed_prefixes();
+                    let suffixes = targets.packed_suffixes();
                     let mut contexts = Vec::with_capacity(num_gpus as usize);
                     for id in 0..num_gpus {
                         let ctx = unsafe {
                             gpu_keypair_init(
                                 id as i32,
-                                prefix.as_ptr(),
-                                prefix.len() as u64,
-                                suffix.as_ptr(),
-                                suffix.len() as u64,
+                                prefixes.as_ptr().cast(),
+                                targets.prefixes.len() as u64,
+                                suffixes.as_ptr().cast(),
+                                targets.suffixes.len() as u64,
                                 ci,
                             )
                         };
@@ -834,13 +1035,11 @@ fn grind_keypair(mut args: GrindKeypairArgs) {
                             let signing_key = SigningKey::from_bytes(&found_seed);
                             let pubkey_bytes = signing_key.verifying_key().to_bytes();
                             let pubkey_str = fd_bs58::encode_32(pubkey_bytes);
-                            let pubkey_check = maybe_bs58_aware_lowercase(&pubkey_str, ci);
                             let count = u64::from_le_bytes(array::from_fn(|j| out[32 + j]));
 
                             fast::add_attempts(count);
 
-                            if pubkey_check.starts_with(prefix) && pubkey_check.ends_with(suffix)
-                            {
+                            if targets.matches(&pubkey_str) {
                                 let prev = fast::note_found();
                                 if prev < target_count {
                                     eprintln!(
@@ -898,8 +1097,8 @@ fn grind_keypair(mut args: GrindKeypairArgs) {
     };
 
     fast::run_cpu_workers(
-        prefix,
-        suffix,
+        &targets.prefixes,
+        &targets.suffixes,
         args.case_insensitive,
         args.num_cpus,
         target_count,
@@ -1213,13 +1412,23 @@ fn print_doppler_result(seed: &[u8; 32], pubkey: &[u8; 32], pubkey_str: &str) {
     }
 }
 
-fn format_target_label(prefix: &str, suffix: &str) -> String {
-    match (prefix.is_empty(), suffix.is_empty()) {
-        (false, false) => format!("{}...{}", prefix, suffix),
-        (false, true) => prefix.to_string(),
-        (true, false) => format!("...{}", suffix),
-        (true, true) => "*".to_string(),
+fn format_target_label(targets: &SearchTargets) -> String {
+    fn format_group(label: &str, patterns: &[String]) -> Option<String> {
+        match patterns {
+            [] => None,
+            [pattern] => Some(format!("{label}={pattern}")),
+            _ => Some(format!("{label}=[{}]", patterns.join(" | "))),
+        }
     }
+
+    [
+        format_group("prefix", &targets.prefixes),
+        format_group("suffix", &targets.suffixes),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>()
+    .join(" AND ")
 }
 
 fn print_keypair_result(seed: &[u8; 32], pubkey: &[u8; 32], pubkey_str: &str) {
@@ -1230,19 +1439,22 @@ fn print_keypair_result(seed: &[u8; 32], pubkey: &[u8; 32], pubkey_str: &str) {
     eprintln!("keypair json (solana-compatible): {:?}", keypair_json);
 }
 
-fn get_validated_bs58(label: &str, value: &Option<String>, case_insensitive: bool) -> &'static str {
-    const BS58_CHARS: &str = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-    if let Some(ref s) = value {
-        for c in s.chars() {
-            assert!(
-                BS58_CHARS.contains(c),
-                "your {label} contains invalid bs58: {c}"
-            );
-        }
-        let validated = maybe_bs58_aware_lowercase(s, case_insensitive);
-        return validated.leak();
+fn parse_bs58_pattern(pattern: &str) -> Result<String, String> {
+    if pattern.is_empty() {
+        return Err("pattern cannot be empty".to_string());
     }
-    ""
+    if pattern.len() > MAX_BS58_ADDRESS_LEN {
+        return Err(format!(
+            "pattern cannot exceed {MAX_BS58_ADDRESS_LEN} characters"
+        ));
+    }
+    if let Some(invalid) = pattern
+        .chars()
+        .find(|character| !BS58_ALPHABET.contains(*character))
+    {
+        return Err(format!("pattern contains invalid base58 character: {invalid}"));
+    }
+    Ok(pattern.to_string())
 }
 
 fn maybe_bs58_aware_lowercase(target: &str, case_insensitive: bool) -> String {
@@ -1256,12 +1468,18 @@ fn maybe_bs58_aware_lowercase(target: &str, case_insensitive: bool) -> String {
     }
 }
 
-fn matches_target(pubkey: &str, prefix: &str, suffix: &str, case_insensitive: bool) -> bool {
+fn matches_pattern(
+    pubkey: &str,
+    pattern: &str,
+    prefix: bool,
+    case_insensitive: bool,
+) -> bool {
     if case_insensitive {
-        (prefix.is_empty() || bs58_ci_matches(pubkey, prefix, true))
-            && (suffix.is_empty() || bs58_ci_matches(pubkey, suffix, false))
+        bs58_ci_matches(pubkey, pattern, prefix)
+    } else if prefix {
+        pubkey.starts_with(pattern)
     } else {
-        pubkey.starts_with(prefix) && pubkey.ends_with(suffix)
+        pubkey.ends_with(pattern)
     }
 }
 
@@ -1290,10 +1508,10 @@ extern "C" {
         id: i32,
         base: *const u8,
         owner: *const u8,
-        target: *const u8,
-        target_len: u64,
-        suffix: *const u8,
-        suffix_len: u64,
+        prefixes: *const u8,
+        prefix_count: u64,
+        suffixes: *const u8,
+        suffix_count: u64,
         case_insensitive: bool,
     ) -> *mut std::ffi::c_void;
     pub fn gpu_grind_launch(ctx: *mut std::ffi::c_void, seed: *const u8);
@@ -1303,10 +1521,10 @@ extern "C" {
 
     pub fn gpu_keypair_init(
         id: i32,
-        prefix: *const u8,
-        prefix_len: u64,
-        suffix: *const u8,
-        suffix_len: u64,
+        prefixes: *const u8,
+        prefix_count: u64,
+        suffixes: *const u8,
+        suffix_count: u64,
         case_insensitive: bool,
     ) -> *mut std::ffi::c_void;
     pub fn gpu_keypair_launch(ctx: *mut std::ffi::c_void, seed: *const u8);
@@ -1361,5 +1579,130 @@ mod tests {
     #[test]
     fn bs58_ci_factor_skips_non_letters() {
         assert_eq!(bs58_ci_factor("1A", ""), 2.0);
+    }
+
+    #[test]
+    fn cli_accepts_repeated_and_comma_delimited_targets() {
+        let command = Command::try_parse_from([
+            "vanity",
+            "grind-keypair",
+            "--prefix",
+            "sun",
+            "--prefix",
+            "moon,mint",
+            "--suffix",
+            "key",
+        ])
+        .unwrap();
+
+        let Command::GrindKeypair(args) = command else {
+            panic!("expected grind-keypair command");
+        };
+        assert_eq!(args.prefix, ["sun", "moon", "mint"]);
+        assert_eq!(args.suffix, ["key"]);
+    }
+
+    #[test]
+    fn cli_requires_a_target() {
+        assert!(Command::try_parse_from(["vanity", "grind-keypair"])
+            .is_err());
+    }
+
+    #[test]
+    fn targets_match_any_prefix_and_any_suffix() {
+        let targets = SearchTargets::new(
+            vec!["sun".to_string(), "moon".to_string()],
+            vec!["key".to_string(), "mint".to_string()],
+            false,
+        );
+        assert!(targets.matches("sun7testkey"));
+        assert!(targets.matches("moon7testmint"));
+        assert!(!targets.matches("sun7testend"));
+        assert!(!targets.matches("star7testkey"));
+    }
+
+    #[test]
+    fn normalization_removes_duplicate_and_redundant_targets() {
+        let targets = SearchTargets::new(
+            vec!["Sun".to_string(), "sun".to_string(), "sunny".to_string()],
+            vec!["mint".to_string(), "int".to_string()],
+            true,
+        );
+        assert_eq!(targets.prefixes, ["sun"]);
+        assert_eq!(targets.suffixes, ["int"]);
+    }
+
+    #[test]
+    fn multi_target_probability_sums_disjoint_alternatives() {
+        let targets = SearchTargets::new(
+            vec!["sun".to_string(), "moon".to_string()],
+            Vec::new(),
+            false,
+        );
+        let expected = bs58_probability("sun", "", false)
+            + bs58_probability("moon", "", false);
+        assert!((targets.probability() - expected).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parser_rejects_invalid_or_overlong_patterns() {
+        assert!(parse_bs58_pattern("zero0").is_err());
+        assert!(parse_bs58_pattern(&"a".repeat(45)).is_err());
+    }
+
+    #[cfg(feature = "gpu")]
+    fn match_plan_matches(plan: &[u32], value: &str, reverse: bool) -> bool {
+        let mut candidates = plan[0];
+        let bytes: Box<dyn Iterator<Item = u8>> = if reverse {
+            Box::new(value.bytes().rev())
+        } else {
+            Box::new(value.bytes())
+        };
+        for (position, byte) in bytes.enumerate() {
+            if position >= MAX_BS58_ADDRESS_LEN {
+                return false;
+            }
+            let symbol = BS58_ALPHABET
+                .as_bytes()
+                .iter()
+                .position(|&candidate| candidate == byte)
+                .unwrap();
+            candidates &= plan[1 + position * 58 + symbol];
+            if candidates & plan[1 + MATCH_PLAN_MASKS + position] != 0 {
+                return true;
+            }
+            if candidates == 0 {
+                return false;
+            }
+        }
+        false
+    }
+
+    #[cfg(feature = "gpu")]
+    #[test]
+    fn gpu_match_plans_use_or_semantics() {
+        let prefixes = vec!["sun".to_string(), "moon".to_string()];
+        let prefix_plan = build_match_plan(&prefixes, true, false);
+        assert!(match_plan_matches(&prefix_plan, "sunset", false));
+        assert!(match_plan_matches(&prefix_plan, "moonbeam", false));
+        assert!(!match_plan_matches(&prefix_plan, "star", false));
+
+        let suffixes = vec!["mint".to_string(), "key".to_string()];
+        let suffix_plan = build_match_plan(&suffixes, false, false);
+        assert!(match_plan_matches(&suffix_plan, "seedmint", true));
+        assert!(match_plan_matches(&suffix_plan, "vanitykey", true));
+        assert!(!match_plan_matches(&suffix_plan, "seed", true));
+    }
+
+    #[cfg(feature = "gpu")]
+    #[test]
+    fn gpu_pattern_limit_returns_a_cli_error() {
+        let prefixes = BS58_ALPHABET
+            .chars()
+            .take(MAX_GPU_PATTERNS + 1)
+            .map(|character| character.to_string())
+            .collect();
+        let targets = SearchTargets::new(prefixes, Vec::new(), false);
+        assert!(targets.validate_gpu_pattern_count().is_err());
     }
 }


### PR DESCRIPTION
This adds multi-target prefix and suffix searching to both `grind` and
  `grind-keypair`.

  Targets can be supplied either as comma-separated values:

 
 ``` vanity grind-keypair --prefix sun,moon,mint --suffix key```

  or by repeating the flag:
```
  vanity grind-keypair \
    --prefix sun \
    --prefix moon \
    --prefix mint \
    --suffix key
```
  Both forms are equivalent.

  Matching uses OR semantics within each group and AND semantics between groups:

  (prefix A OR prefix B) AND (suffix A OR suffix B)

  Existing single-target commands remain compatible.

  ## Implementation

  - Added target normalization and removal of duplicate or redundant patterns.
  - Extended the scalar and SIMD CPU matchers.
  - Added compact bitmask-based match plans for CUDA and OpenCL.
  - GPU backends support up to 32 non-redundant prefixes and 32 suffixes.
  - Updated probability and expected-attempt calculations for multiple targets.
  - Added CLI, normalization, matching, probability, and GPU match-plan tests.
  - GPU results continue to be reconstructed and verified with ed25519-dalek
    before being reported.

  - Keypair and seed generation are unchanged; this only extends the matching
    stage.

## Validation

  Tested on one Fedora Linux machine with an NVIDIA CUDA compute capability 8.6
  GPU and GCC/G++ 15.

  cargo test
  31 passed

  CC=gcc-15 CXX=g++-15 VANITY_CUDA_ARCH=86 \
  cargo test --features gpu
  33 passed

  CC=gcc-15 CXX=g++-15 VANITY_CUDA_ARCH=86 \
  cargo build --release --features gpu
  passed

  A multi-target CUDA runtime test reached approximately 32.7 million
  attempts/second, comparable to the existing optimized installation on the same
  machine. [rtx 3090]

  I was unable to compile or run the OpenCL backend because this system does not
  have the OpenCL development headers. I would appreciate additional
  testing on OpenCL and other CUDA architectures before merging.